### PR TITLE
fixed issue with (not)has query

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -236,6 +236,17 @@ var parseQuery = function (query, options) {
         } else if (operator == '!c') {
           val = val.split('/');
           addCondition(lcKey, {'$not': new RegExp(val[0], val[1])});
+        } else if (operator == 'deq' || operator == 'dne' ) {
+          //deq - date equals
+          //dne - date not equals
+          var temp = Date.parse(val);
+          if (isNaN(temp)) {
+            throw new Error(`Invalid options for operator "${operator}"`);
+          }
+          var dateStart = new Date(new Date(temp).setUTCHours(0,0,0,0));
+          var dateEnd = new Date(dateStart.getTime() + 86400000);
+          var dateRange = {'$gte': dateStart, '$lt': dateEnd};
+          addCondition(lcKey, operator == 'dne' ? { '$not': dateRange }: dateRange);
         } else {
           if (options.ignoreKeys === true) return;
           if (options.ignoreKeys && typeof options.ignoreKeys.indexOf === 'function' && options.ignoreKeys.indexOf(key) != -1) return;
@@ -325,7 +336,7 @@ var parseQuery = function (query, options) {
 }
 
 function escapeRegExp(str) {
-	return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+  return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
 }
 var doQuery = function (query, model, options, callback) {
   if (dbg) console.log(query);

--- a/lib/index.js
+++ b/lib/index.js
@@ -235,7 +235,7 @@ var parseQuery = function (query, options) {
           addCondition(lcKey, new RegExp(val[0], val[1]));
         } else if (operator == '!c') {
           val = val.split('/');
-          addCondition(lcKey, {'$ne': new RegExp(val[0], val[1])});
+          addCondition(lcKey, {'$not': new RegExp(val[0], val[1])});
         } else {
           if (options.ignoreKeys === true) return;
           if (options.ignoreKeys && typeof options.ignoreKeys.indexOf === 'function' && options.ignoreKeys.indexOf(key) != -1) return;


### PR DESCRIPTION
## Fixes:

```
Mongoose: _listing_seller.find({ 'rels.seller.firstName': { '$ne': /lorian/ } }, { sort: { createdAt: -1 }, limit: 100, projection: { proposals: 0 } })
Mongoose: _listing_seller.countDocuments({ 'rels.seller.firstName': { '$ne': /lorian/ } }, { sort: { createdAt: -1 }, limit: undefined, skip: 0 })
MongoError: Can't have regex as arg to $ne.
```

## New Operators : (proposal)
- deq : date equals
- dne : date not equals